### PR TITLE
Setup scss file structure

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -4,27 +4,17 @@
 defined('MOODLE_INTERNAL') || die();
 
 function theme_citricityxund_get_main_scss_content($theme) {                                                                                
-    global $CFG;                                                                                                                    
-                                                                                                                                    
-    $scss = '';                                                                                                                     
-    $filename = !empty($theme->settings->preset) ? $theme->settings->preset : null;                                                 
-    $fs = get_file_storage();                                                                                                       
-                                                                                                                                    
-    $context = context_system::instance();                                                                                          
-    if ($filename == 'default.scss') {                                                                                              
-        // We still load the default preset files directly from the boost theme. No sense in duplicating them.                      
-        $scss .= file_get_contents($CFG->dirroot . '/theme/boost/scss/preset/default.scss');                                        
-    } else if ($filename == 'plain.scss') {                                                                                         
-        // We still load the default preset files directly from the boost theme. No sense in duplicating them.                      
-        $scss .= file_get_contents($CFG->dirroot . '/theme/boost/scss/preset/plain.scss');                                          
-                                                                                                                                    
-    } else if ($filename && ($presetfile = $fs->get_file($context->id, 'theme_citricityxund', 'preset', 0, '/', $filename))) {              
-        // This preset file was fetched from the file area for theme_citricityxund and not theme_boost (see the line above).                
-        $scss .= $presetfile->get_content();                                                                                        
-    } else {                                                                                                                        
-        // Safety fallback - maybe new installs etc.                                                                                
-        $scss .= file_get_contents($CFG->dirroot . '/theme/boost/scss/preset/default.scss');                                        
-    }                                                                                                                                       
-                                                                                                                                    
-    return $scss;                                                                                                                   
+    global $CFG;
+
+    $scss = [];
+    // Pre CSS - this is loaded AFTER any prescss from the setting but before the main scss.
+    $scss[] = file_get_contents($CFG->dirroot . '/theme/citricityxund/scss/pre.scss');
+
+    $scss[] = file_get_contents($CFG->dirroot . '/theme/citricityxund/scss/main.scss');
+
+    // Post CSS - this is loaded AFTER the main scss but before the extra scss from the setting.
+    $scss[] = file_get_contents($CFG->dirroot . '/theme/citricityxund/scss/post.scss');
+
+    // Combine them together.
+    return implode("\n", $scss);                                                                                                                 
 }

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -1,0 +1,14 @@
+// Import FontAwesome.
+@import "fontawesome";
+
+// Import All of Bootstrap
+@import "bootstrap";
+
+// Import Core moodle CSS
+@import "moodle";
+
+// Import General CSS Styling.
+@import "styles/general";
+
+// Import Navbar CSS Styling.
+@import "styles/navbar";

--- a/scss/post.scss
+++ b/scss/post.scss
@@ -1,0 +1,1 @@
+// Post SCSS for the theme.

--- a/scss/pre.scss
+++ b/scss/pre.scss
@@ -1,0 +1,111 @@
+// Pre SCSS for the theme.
+
+// Bootstrap variables
+$white:    #fff !default;
+$gray-100: #f8f9fa !default;
+$gray-200: #e9ecef !default;
+$gray-300: #dee2e6 !default;
+$gray-400: #ced4da !default;
+$gray-500: #8f959e !default;
+$gray-600: #6a737b !default;
+$gray-700: #495057 !default;
+$gray-800: #343a40 !default;
+$gray-900: #1d2125 !default;
+$black:    #000 !default;
+
+$blue:    #0f6cbf !default;
+$indigo:  #6610f2 !default;
+$purple:  #613d7c !default;
+$pink:    #e83e8c !default;
+$red:     #ca3120 !default;
+$orange:  #f0ad4e !default;
+$yellow:  #ff7518 !default;
+$green:   #357a32 !default;
+$teal:    #20c997 !default;
+$cyan:    #008196 !default;
+
+$primary:       $blue !default;
+$success:       $green !default;
+$info:          $cyan !default;
+$warning:       $orange !default;
+$danger:        $red !default;
+$secondary:     $gray-400 !default;
+
+$info-outline:    #1f7e9a;
+$warning-outline: #a6670e;
+
+// Tables
+$table-accent-bg:             rgba($black, .03) !default;
+
+// Options
+$enable-rounded: false !default;
+$enable-responsive-font-sizes: true !default;
+
+// Body
+$body-color:    $gray-900 !default;
+
+// Fonts
+$font-size-base: 0.9375rem !default;
+$rfs-base-font-size: 0.9rem !default;
+$headings-font-weight:   300 !default;
+
+// Navbar
+$navbar-dark-hover-color:           rgba($white, 1) !default;
+$navbar-light-color:                rgba($black, 0.6) !default;
+$navbar-light-hover-color:          rgba($black, .9) !default;
+
+// Breadcrumbs
+$breadcrumb-padding-y:              .25rem !default;
+$breadcrumb-padding-x:              0 !default;
+$breadcrumb-item-padding:           .5rem !default;
+$breadcrumb-margin-bottom:          0 !default;
+$breadcrumb-bg:                     transparent !default;
+$breadcrumb-divider: "/" !default;
+$breadcrumb-divider-rtl: "/" !default;
+
+// Floating elements positions
+$gototop-bottom-position: 50px !default;
+
+// Alerts
+$alert-border-width:                0 !default;
+
+$card-group-margin: .25rem;
+
+// Toasts
+$toast-color:                       $white !default;
+$toast-background-color:            rgba($gray-900, .95) !default;
+$toast-header-color:                $gray-100 !default;
+$toast-header-background-color:     rgba($white, .1) !default;
+
+// Custom control size
+$custom-control-indicator-size: 1.25rem;
+
+$input-btn-focus-color: rgba($primary, .75) !default;
+
+$input-border-color: $gray-500 !default;
+
+$dropdown-link-hover-color: $white;
+$dropdown-link-hover-bg: $primary;
+
+// stylelint-disable
+$theme-colors: () !default;
+$theme-colors: map-merge((
+    primary: $primary,
+    secondary: $secondary,
+    success: $success,
+    info: $info,
+    warning: $warning,
+    danger: $danger,
+), $theme-colors);
+// stylelint-enable
+
+$spacer: 1rem !default;
+$spacers: (
+    0: 0,
+    1: ($spacer * .25),
+    2: ($spacer * .5),
+    3: $spacer,
+    4: ($spacer * 1.5),
+    5: ($spacer * 2),
+    6: ($spacer * 3)
+) !default;

--- a/scss/styles/general.scss
+++ b/scss/styles/general.scss
@@ -1,0 +1,27 @@
+body {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
+// Rounded user pictures
+.userpicture {
+    border-radius: 50%;
+}
+
+// Reset the default styling back to the bootstrap defaults for
+// the secondary outline button because gray-200 is much too light
+// for an outline button.
+.btn-outline-secondary {
+    @include button-outline-variant($gray-600);
+    border-color: $gray-600;
+}
+
+.btn-outline-info {
+    @include button-outline-variant($info-outline);
+}
+
+.btn-outline-warning {
+    @include button-outline-variant($warning-outline);
+}
+
+@include bg-variant(".bg-gray", $gray-200, true);

--- a/scss/styles/navbar.scss
+++ b/scss/styles/navbar.scss
@@ -1,0 +1,3 @@
+.navbar {
+    box-shadow: 0 2px 4px rgba(0, 0, 0, .08);
+}

--- a/settings.php
+++ b/settings.php
@@ -11,40 +11,7 @@ if ($ADMIN->fulltree) {
     $settings = new theme_boost_admin_settingspage_tabs('themesettingcitricityxund', get_string('configtitle', 'theme_citricityxund'));             
                                                                                                                                     
     // Each page is a tab - the first is the "General" tab.                                                                         
-    $page = new admin_settingpage('theme_citricityxund_general', get_string('generalsettings', 'theme_citricityxund'));                             
-                                                                                                                                    
-    // Replicate the preset setting from boost.                                                                                     
-    $name = 'theme_citricityxund/preset';                                                                                                   
-    $title = get_string('preset', 'theme_citricityxund');                                                                                   
-    $description = get_string('preset_desc', 'theme_citricityxund');                                                                        
-    $default = 'default.scss';                                                                                                      
-                                                                                                                                    
-    // We list files in our own file area to add to the drop down. We will provide our own function to                              
-    // load all the presets from the correct paths.                                                                                 
-    $context = context_system::instance();                                                                                          
-    $fs = get_file_storage();                                                                                                       
-    $files = $fs->get_area_files($context->id, 'theme_citricityxund', 'preset', 0, 'itemid, filepath, filename', false);                    
-                                                                                                                                    
-    $choices = [];                                                                                                                  
-    foreach ($files as $file) {                                                                                                     
-        $choices[$file->get_filename()] = $file->get_filename();                                                                    
-    }                                                                                                                               
-    // These are the built in presets from Boost.                                                                                   
-    $choices['default.scss'] = 'default.scss';                                                                                      
-    $choices['plain.scss'] = 'plain.scss';                                                                                          
-                                                                                                                                    
-    $setting = new admin_setting_configselect($name, $title, $description, $default, $choices);                                     
-    $setting->set_updatedcallback('theme_reset_all_caches');                                                                        
-    $page->add($setting);                                                                                                           
-                                                                                                                                    
-    // Preset files setting.                                                                                                        
-    $name = 'theme_citricityxund/presetfiles';                                                                                              
-    $title = get_string('presetfiles','theme_citricityxund');                                                                               
-    $description = get_string('presetfiles_desc', 'theme_citricityxund');                                                                   
-                                                                                                                                    
-    $setting = new admin_setting_configstoredfile($name, $title, $description, 'preset', 0,                                         
-        array('maxfiles' => 20, 'accepted_types' => array('.scss')));                                                               
-    $page->add($setting);     
+    $page = new admin_settingpage('theme_citricityxund_general', get_string('generalsettings', 'theme_citricityxund'));                                                                                                                                 
 
     // Variable $brand-color.                                                                                                       
     // We use an empty default value because the default colour should come from the preset.                                        


### PR DESCRIPTION
I have set up our SCSS file structure for styling the theme. The actual SCSS code in the files is a broken down "default.scss" from Boost to use as a starting point.

To do this I...

- Set up a SCSS folder to contain the SCSS.
- Created a pre.scss file to contain our variables
- Created a main.scss to load all the main scss components
- Created a post.scss to house any SCSS we want to load after the main code.
- Created a styles folder to house the component SCSS files.
- Created a navbar and general SCSS files for now, using code from default.scss as a base. I then imported these files into our main.scss.

After this I updated our lib.php theme_citricityxund_get_main_scss_content function to render these scss files in the order pre, main, post.

I also removed the default Boost setting for preset files from settings.php as we will not be using these in this theme.
