### PR TITLE
Basic brand variable values

### DIFF
--- a/scss/pre.scss
+++ b/scss/pre.scss
@@ -24,12 +24,12 @@ $green:   #357a32 !default;
 $teal:    #20c997 !default;
 $cyan:    #008196 !default;
 
-$primary:       $blue !default;
+$primary:       #3a7cb8 !default;
 $success:       $green !default;
 $info:          $cyan !default;
 $warning:       $orange !default;
 $danger:        $red !default;
-$secondary:     $gray-400 !default;
+$secondary:     #eb4f5a !default;
 
 $info-outline:    #1f7e9a;
 $warning-outline: #a6670e;
@@ -42,12 +42,15 @@ $enable-rounded: false !default;
 $enable-responsive-font-sizes: true !default;
 
 // Body
-$body-color:    $gray-900 !default;
+$body-color:    $primary !default;
 
 // Fonts
+$font-family-sans-serif: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" !default;
+$headings-font-family: null !default;
 $font-size-base: 0.9375rem !default;
 $rfs-base-font-size: 0.9rem !default;
-$headings-font-weight:   300 !default;
+$headings-font-weight: 700 !default;
+$headings-color: $primary !default;
 
 // Navbar
 $navbar-dark-hover-color:           rgba($white, 1) !default;

--- a/scss/styles/general.scss
+++ b/scss/styles/general.scss
@@ -25,3 +25,8 @@ body {
 }
 
 @include bg-variant(".bg-gray", $gray-200, true);
+
+// Stop radius defaulting to zero.
+.btn { 
+    border-radius: $btn-border-radius;
+}


### PR DESCRIPTION
Added some basic branding values from the Zeplin style sheet.

- Primary colour 
- Secondary colour
- Body colour
- Heading colour
- Heading font-weight
- Default heading and body fonts which need updating

Added some CSS as btn was not inheriting the value of btn-border-radius. This is because in the mockups buttons are slightly rounded.