### PR TITLE
Dashboard styling and layout.

### DIFF
--- a/config.php
+++ b/config.php
@@ -93,9 +93,8 @@ $THEME->layouts = [
     ),
     // My dashboard page.
     'mydashboard' => array(
-        'file' => 'columns2.php',
-        'regions' => array('side-pre'),
-        'defaultregion' => 'side-pre',
+        'file' => 'mydashboard.php',
+        'regions' => [],
         'options' => array('nonavbar' => true, 'langmenu' => true, 'nocontextheader' => true),
     ),
     // My public page.

--- a/layout/mydashboard.php
+++ b/layout/mydashboard.php
@@ -1,0 +1,41 @@
+<?php
+
+defined('MOODLE_INTERNAL') || die();
+
+user_preference_allow_ajax_update('drawer-open-nav', PARAM_ALPHA);
+require_once($CFG->libdir . '/behat/lib.php');
+
+if (isloggedin()) {
+    $navdraweropen = (get_user_preferences('drawer-open-nav', 'true') == 'true');
+} else {
+    $navdraweropen = false;
+}
+$extraclasses = [];
+if ($navdraweropen) {
+    $extraclasses[] = 'drawer-open-left';
+}
+$bodyattributes = $OUTPUT->body_attributes($extraclasses);
+$blockshtml = $OUTPUT->blocks('side-pre');
+$hasblocks = strpos($blockshtml, 'data-block=') !== false;
+$buildregionmainsettings = !$PAGE->include_region_main_settings_in_header_actions();
+// If the settings menu will be included in the header then don't add it here.
+$regionmainsettingsmenu = $buildregionmainsettings ? $OUTPUT->region_main_settings_menu() : false;
+$templatecontext = [
+    'sitename' => format_string($SITE->shortname, true, ['context' => context_course::instance(SITEID), "escape" => false]),
+    'output' => $OUTPUT,
+    'sidepreblocks' => $blockshtml,
+    'hasblocks' => $hasblocks,
+    'bodyattributes' => $bodyattributes,
+    'navdraweropen' => $navdraweropen,
+    'regionmainsettingsmenu' => $regionmainsettingsmenu,
+    'hasregionmainsettingsmenu' => !empty($regionmainsettingsmenu),
+    'logo' => $OUTPUT->image_url('logo', 'theme_citricityxund'),
+    'moodlelogo' => $OUTPUT->image_url('moodlelogo', 'theme_citricityxund'),
+    'logofull' => $OUTPUT->image_url('logofull', 'theme_citricityxund'),
+];
+
+$nav = $PAGE->flatnav;
+$templatecontext['flatnavigation'] = $nav;
+$templatecontext['firstcollectionlabel'] = $nav->get_collectionlabel();
+echo $OUTPUT->render_from_template('theme_citricityxund/mydashboard', $templatecontext);
+

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -21,3 +21,6 @@
 
 // Import Nav-drawer CSS Styling.
 @import "styles/navdrawer";
+
+// Import My dashboard CSS Styling.
+@import "styles/mydashboard";

--- a/scss/pre.scss
+++ b/scss/pre.scss
@@ -97,6 +97,7 @@ $dropdown-link-hover-color: $white;
 $dropdown-link-hover-bg: $primary;
 
 $drawer-bg: #f6f8f9;
+$dashboard-bg: $white !default;
 
 // List group items
 $list-group-border-color: #f6f8f9 !default;

--- a/scss/styles/general.scss
+++ b/scss/styles/general.scss
@@ -12,8 +12,8 @@ body {
 // the secondary outline button because gray-200 is much too light
 // for an outline button.
 .btn-outline-secondary {
-    @include button-outline-variant($gray-600);
-    border-color: $gray-600;
+    @include button-outline-variant($primary);
+    border-color: $primary;
 }
 
 .btn-outline-info {

--- a/scss/styles/mydashboard.scss
+++ b/scss/styles/mydashboard.scss
@@ -1,0 +1,51 @@
+.pagelayout-mydashboard {
+    // Remove block card border and heading card border.
+    .block.card,
+    #page-header .card {
+        border: none;
+    }
+
+    // Alternate block background color.
+    #block-region-content>.block:nth-child(odd) {
+        background-color: darken($body-bg, 3%);
+    }
+
+    // Recently accessed courses.
+    .block-recentlyaccessedcourses {
+        // Style page links.
+        .page-item.disabled .page-link,
+        .page-link {
+            border: 0;
+            background-color: transparent;
+        }
+    }
+
+    .block_myoverview>.card-body {
+        // Move filters to same row for large devices.
+        @include media-breakpoint-up(lg) {
+            position: relative;
+            [data-region="filter"] {
+                position: absolute;
+                top: 28px;
+                right: 2rem;
+            }
+        }
+    }
+}
+
+// Dashboard card styling.
+.dashboard-card-deck .dashboard-card {
+    border-radius: 0.75rem;
+    border: 0;
+    box-shadow: 1.5px 1.5px 3px 0 rgba(0, 0, 0, 0.15);
+
+    .dashboard-card-img {
+        border-top-left-radius: 0.75rem;
+        border-top-right-radius: 0.75rem;
+    }
+}
+
+// Consistent width dashboard cards.
+body.drawer-open-left .dashboard-card-deck:not(.fixed-width-cards) .dashboard-card {
+    width: 300px;
+}

--- a/templates/block_myoverview/main.mustache
+++ b/templates/block_myoverview/main.mustache
@@ -1,10 +1,9 @@
 <div id="block-myoverview-{{uniqid}}" class="block-myoverview block-cards" data-region="myoverview" role="navigation">
+    <div data-region="filter" class="d-flex align-items-center flex-wrap" aria-label="{{#str}} aria:controls, block_myoverview {{/str}}">
+        {{> block_myoverview/nav-grouping-selector }}
 
-            <div data-region="filter" class="d-flex align-items-center flex-wrap" aria-label="{{#str}} aria:controls, block_myoverview {{/str}}">
-                {{> block_myoverview/nav-grouping-selector }}
-
-                {{> block_myoverview/nav-sort-selector }}
-            </div>
+        {{> block_myoverview/nav-sort-selector }}
+    </div>
 
     <div class="container-fluid p-0">
         {{> block_myoverview/courses-view }}

--- a/templates/block_myoverview/main.mustache
+++ b/templates/block_myoverview/main.mustache
@@ -1,0 +1,26 @@
+<div id="block-myoverview-{{uniqid}}" class="block-myoverview block-cards" data-region="myoverview" role="navigation">
+
+            <div data-region="filter" class="d-flex align-items-center flex-wrap" aria-label="{{#str}} aria:controls, block_myoverview {{/str}}">
+                {{> block_myoverview/nav-grouping-selector }}
+
+                {{> block_myoverview/nav-sort-selector }}
+            </div>
+
+    <div class="container-fluid p-0">
+        {{> block_myoverview/courses-view }}
+    </div>
+</div>
+{{#js}}
+require(
+[
+    'jquery',
+    'block_myoverview/main',
+],
+function(
+    $,
+    Main
+) {
+    var root = $('#block-myoverview-{{uniqid}}');
+    Main.init(root);
+});
+{{/js}}

--- a/templates/block_myoverview/nav-grouping-selector.mustache
+++ b/templates/block_myoverview/nav-grouping-selector.mustache
@@ -1,0 +1,111 @@
+{{#displaygroupingselector}}
+<div class="dropdown mb-1 mr-auto">
+    <button id="groupingdropdown" type="button" class="btn btn-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="{{#str}} aria:groupingdropdown, block_myoverview {{/str}}">
+        {{#pix}} i/filter {{/pix}}
+        <span class="d-sm-inline-block" data-active-item-text>
+            {{#allincludinghidden}}{{#str}} allincludinghidden, block_myoverview {{/str}}{{/allincludinghidden}}
+            {{#all}}{{#str}} all, block_myoverview {{/str}}{{/all}}
+            {{#inprogress}}{{#str}} inprogress, block_myoverview {{/str}}{{/inprogress}}
+            {{#future}}{{#str}} future, block_myoverview {{/str}}{{/future}}
+            {{#past}}{{#str}} past, block_myoverview {{/str}}{{/past}}
+            {{#favourites}}{{#str}} favourites, block_myoverview {{/str}}{{/favourites}}
+            {{#hidden}}{{#str}} hiddencourses, block_myoverview {{/str}}{{/hidden}}
+            {{selectedcustomfield}}
+        </span>
+    </button>
+    <ul class="dropdown-menu" role="menu" data-show-active-item data-skip-active-class="true" data-active-item-text aria-labelledby="groupingdropdown">
+        {{#displaygroupingallincludinghidden}}
+        <li>
+            <a class="dropdown-item" href="#" data-filter="grouping" data-value="allincludinghidden" data-pref="allincludinghidden" aria-label="{{#str}} aria:allcoursesincludinghidden, block_myoverview {{/str}}" aria-controls="courses-view-{{uniqid}}" role="menuitem" {{#allincludinghidden}}aria-current="true"{{/allincludinghidden}}>
+                {{#str}} allincludinghidden, block_myoverview {{/str}}
+            </a>
+        </li>
+        {{/displaygroupingallincludinghidden}}
+        {{#displaygroupingall}}
+        <li class="dropdown-divider" role="presentation">
+            <span class="filler">&nbsp;</span>
+        </li>
+        <li>
+            <a class="dropdown-item" href="#" data-filter="grouping" data-value="all" data-pref="all" aria-label="{{#str}} aria:allcourses, block_myoverview {{/str}}" aria-controls="courses-view-{{uniqid}}" role="menuitem" {{#all}}aria-current="true"{{/all}}>
+                {{#str}} all, block_myoverview {{/str}}
+            </a>
+        </li>
+        {{/displaygroupingall}}
+        {{#displaygroupinginprogress}}
+        <li class="dropdown-divider" role="presentation">
+            <span class="filler">&nbsp;</span>
+        </li>
+        <li>
+            <a class="dropdown-item" href="#" data-filter="grouping" data-value="inprogress" data-pref="inprogress" aria-label="{{#str}} aria:inprogress, block_myoverview {{/str}}" aria-controls="courses-view-{{uniqid}}" role="menuitem" {{#inprogress}}aria-current="true"{{/inprogress}}>
+                {{#str}} inprogress, block_myoverview {{/str}}
+            </a>
+        </li>
+        {{/displaygroupinginprogress}}
+        {{#displaygroupingfuture}}
+            {{^displaygroupinginprogress}}
+            <li class="dropdown-divider" role="presentation">
+                <span class="filler">&nbsp;</span>
+            </li>
+            {{/displaygroupinginprogress}}
+        <li>
+            <a class="dropdown-item" href="#" data-filter="grouping" data-value="future" data-pref="future" aria-label="{{#str}} aria:future, block_myoverview {{/str}}" aria-controls="courses-view-{{uniqid}}" role="menuitem" {{#future}}aria-current="true"{{/future}}>
+                {{#str}} future, block_myoverview {{/str}}
+            </a>
+        </li>
+        {{/displaygroupingfuture}}
+        {{#displaygroupingpast}}
+            {{^displaygroupinginprogress}}
+                {{^displaygroupingfuture}}
+                <li class="dropdown-divider" role="presentation">
+                    <span class="filler">&nbsp;</span>
+                </li>
+                {{/displaygroupingfuture}}
+            {{/displaygroupinginprogress}}
+        <li>
+            <a class="dropdown-item" href="#" data-filter="grouping" data-value="past" data-pref="past" aria-label="{{#str}} aria:past, block_myoverview {{/str}}" aria-controls="courses-view-{{uniqid}}" role="menuitem" {{#past}}aria-current="true"{{/past}}>
+                {{#str}} past, block_myoverview {{/str}}
+            </a>
+        </li>
+        {{/displaygroupingpast}}
+        {{#displaygroupingcustomfield}}
+            <li class="dropdown-divider" role="presentation">
+                <span class="filler">&nbsp;</span>
+            </li>
+            {{#customfieldvalues}}
+                <li>
+                    <a class="dropdown-item" href="#" data-filter="grouping"
+                       data-value="customfield" data-pref="customfield" data-customfieldvalue="{{value}}"
+                       aria-label="{{#str}}aria:customfield, block_myoverview, {{name}}{{/str}}"
+                       aria-controls="courses-view-{{uniqid}}" role="menuitem" {{#active}}aria-current="true"{{/active}}>
+                        {{name}}
+                    </a>
+                </li>
+            {{/customfieldvalues}}
+        {{/displaygroupingcustomfield}}
+        {{#displaygroupingfavourites}}
+        <li class="dropdown-divider" role="presentation">
+            <span class="filler">&nbsp;</span>
+        </li>
+        <li>
+            <a class="dropdown-item" href="#" data-filter="grouping" data-value="favourites"  data-pref="favourites" aria-label="{{#str}} aria:favourites, block_myoverview {{/str}}" aria-controls="courses-view-{{uniqid}}" role="menuitem" {{#favourites}}aria-current="true"{{/favourites}}>
+                {{#str}} favourites, block_myoverview {{/str}}
+            </a>
+        {{/displaygroupingfavourites}}
+        {{#displaygroupinghidden}}
+        <li class="dropdown-divider" role="presentation">
+            <span class="filler">&nbsp;</span>
+        </li>
+        <li>
+            <a class="dropdown-item" href="#" data-filter="grouping" data-value="hidden"  data-pref="hidden" aria-label="{{#str}} aria:hiddencourses, block_myoverview {{/str}}" aria-controls="courses-view-{{uniqid}}" role="menuitem" {{#hidden}}aria-current="true"{{/hidden}}>
+                {{#str}} hiddencourses, block_myoverview {{/str}}
+            </a>
+        </li>
+        {{/displaygroupinghidden}}
+    </ul>
+</div>
+{{/displaygroupingselector}}
+{{^displaygroupingselector}}
+<div class="mb-1 mr-auto">
+    <span class="filler">&nbsp;</span>
+</div>
+{{/displaygroupingselector}}

--- a/templates/block_myoverview/nav-sort-selector.mustache
+++ b/templates/block_myoverview/nav-sort-selector.mustache
@@ -1,0 +1,31 @@
+<div class="mb-1 mr-1 d-flex align-items-center">
+    <div class="dropdown">
+        <button id="sortingdropdown" type="button" class="btn btn-link dropdown-toggle" data-toggle="dropdown"  aria-haspopup="true" aria-expanded="false" aria-label="{{#str}} aria:sortingdropdown, block_myoverview {{/str}}">
+            {{#pix}} t/sort_by {{/pix}}
+            <span class="d-sm-inline-block" data-active-item-text>
+                {{#title}}{{#str}} title, block_myoverview {{/str}}{{/title}}
+                {{#lastaccessed}}{{#str}} lastaccessed, block_myoverview {{/str}}{{/lastaccessed}}
+                {{#shortname}}{{#str}} shortname, block_myoverview {{/str}}{{/shortname}}
+            </span>
+        </button>
+        <ul class="dropdown-menu" role="menu" data-show-active-item data-skip-active-class="true" aria-labelledby="sortingdropdown">
+            <li>
+                <a class="dropdown-item" href="#" data-filter="sort" data-pref="title" data-value="fullname" aria-label="{{#str}} aria:title, block_myoverview {{/str}}" aria-controls="courses-view-{{uniqid}}" role="menuitem" {{#title}}aria-current="true"{{/title}}>
+                    {{#str}} title, block_myoverview {{/str}}
+                </a>
+            </li>
+            {{#showsortbyshortname}}
+            <li>
+                <a class="dropdown-item" href="#" data-filter="sort" data-pref="shortname" data-value="shortname" aria-label="{{#str}} aria:shortname, block_myoverview {{/str}}" aria-controls="courses-view-{{uniqid}}" role="menuitem" {{#shortname}}aria-current="true"{{/shortname}}>
+                    {{#str}} shortname, block_myoverview {{/str}}
+                </a>
+            </li>
+             {{/showsortbyshortname}}
+            <li>
+                <a class="dropdown-item" href="#" data-filter="sort" data-pref="lastaccessed" data-value="ul.timeaccess desc" aria-label="{{#str}} aria:lastaccessed, block_myoverview {{/str}}" aria-controls="courses-view-{{uniqid}}" role="menuitem" {{#lastaccessed}}aria-current="true"{{/lastaccessed}}>
+                    {{#str}} lastaccessed, block_myoverview {{/str}}
+                </a>
+            </li>
+        </ul>
+    </div>
+</div>

--- a/templates/core/block.mustache
+++ b/templates/core/block.mustache
@@ -1,0 +1,48 @@
+{{! Block Skip Link }}
+{{#showskiplink}}
+  <a href="#sb-{{skipid}}" class="sr-only sr-only-focusable">{{#str}}skipa, access, {{{title}}}{{/str}}</a>
+{{/showskiplink}}
+
+{{! Start Block Container }}
+<section id="{{id}}"
+     class="{{#hidden}}hidden{{/hidden}} {{class}} {{#hascontrols}}block_with_controls{{/hascontrols}} card"
+     role="{{ariarole}}"
+     data-block="{{type}}"
+     {{#arialabel}}
+        aria-label="{{arialabel}}"
+     {{/arialabel}}
+     {{^arialabel}}
+        {{#title}}
+          aria-labelledby="instance-{{blockinstanceid}}-header"
+        {{/title}}
+     {{/arialabel}}>
+
+    {{! Block contents }}
+    <div class="card-body p-5">
+
+        {{! Block header }}
+        {{#title}}
+            <h5 id="instance-{{blockinstanceid}}-header" class="h4 card-title d-inline">{{{title}}}</h5>
+        {{/title}}
+
+        {{#hascontrols}}
+            <div class="block-controls float-right header">
+                {{{controls}}}
+            </div>
+        {{/hascontrols}}
+
+        <div class="card-text content mt-3">
+            {{{content}}}
+            <div class="footer">{{{footer}}}</div>
+            {{{annotation}}}
+        </div>
+
+    </div>
+
+{{! End Block Container }}
+</section>
+
+{{! Block Skip Link Target }}
+{{#showskiplink}}
+  <span id="sb-{{skipid}}"></span>
+{{/showskiplink}}

--- a/templates/core_course/coursecard.mustache
+++ b/templates/core_course/coursecard.mustache
@@ -1,0 +1,41 @@
+<div class="card dashboard-card" role="listitem"
+    data-region="course-content"
+    data-course-id="{{{id}}}">
+    <a href="{{viewurl}}" tabindex="-1">
+        <div class="card-img dashboard-card-img" style='background-image: url("{{{courseimage}}}");'>
+            <span class="sr-only">{{#str}}aria:courseimage, core_course{{/str}}</span>
+        </div>
+    </a>
+    <div class="card-body pr-1 course-info-container" id="course-info-container-{{id}}-{{uniqid}}">
+        <div class="d-flex align-items-start">
+            <div class="w-100 text-truncate">
+                <a href="{{viewurl}}" class="aalink coursename mr-2 text-uppercase h6">
+                    {{> core_course/favouriteicon }}
+                    <span class="sr-only">
+                            {{#str}}aria:coursename, core_course{{/str}}
+                        </span>
+                    {{$coursename}}{{/coursename}}
+                </a>
+                <div class="text-muted muted d-flex mb-1 flex-wrap">
+                    {{$coursecategory}}{{/coursecategory}}
+                    {{#showshortname}}
+                    {{$divider}}{{/divider}}
+                    <span class="sr-only">
+                        {{#str}}aria:courseshortname, core_course{{/str}}
+                    </span>
+                    <div>
+                        {{{shortname}}}
+                    </div>
+                    {{/showshortname}}
+                </div>
+                {{^visible}}
+                    <div class="d-flex flex-wrap">
+                        <span class="badge badge-info">{{#str}} hiddenfromstudents {{/str}}</span>
+                    </div>
+                {{/visible}}
+            </div>
+            {{$menu}}{{/menu}}
+        </div>
+    </div>
+    {{$progress}}{{/progress}}
+</div>

--- a/templates/flat_navigation.mustache
+++ b/templates/flat_navigation.mustache
@@ -1,14 +1,5 @@
 <nav class="list-group" aria-label="{{firstcollectionlabel}}">
     <ul>
-        <li>
-            <a class="list-group-item list-heading-logo" href="{{{ config.wwwroot }}}">
-                <div class="ml-0">
-                    <div class="media">
-                        <img src="{{logofull}}" class="logo mr-1 w-75" alt="{{sitename}}">
-                    </div>
-                </div>
-            </a>
-        </li>
     {{# flatnavigation }}
         {{#showdivider}}
             </ul>

--- a/templates/mydashboard.mustache
+++ b/templates/mydashboard.mustache
@@ -1,0 +1,54 @@
+{{> theme_boost/head }}
+
+<body {{{ bodyattributes }}}>
+{{> core/local/toast/wrapper}}
+
+<div id="page-wrapper" class="d-print-block">
+
+    {{{ output.standard_top_of_body_html }}}
+
+    {{> theme_citricityxund/navbar }}
+    {{> theme_citricityxund/nav-drawer }}
+
+    <div id="page" class="container-fluid d-print-block">
+        {{{ output.full_header }}}
+
+        <div id="page-content" class="row pb-3 d-print-block">
+            <div id="region-main-box" class="col-12 px-0">
+                {{#hasregionmainsettingsmenu}}
+                <div id="region-main-settings-menu" class="d-print-none {{#hasblocks}}has-blocks{{/hasblocks}}">
+                    <div> {{{ output.region_main_settings_menu }}} </div>
+                </div>
+                {{/hasregionmainsettingsmenu}}
+                <section id="region-main" {{#hasblocks}}class="has-blocks mb-3"{{/hasblocks}} aria-label="{{#str}}content{{/str}}">
+
+                    {{#hasregionmainsettingsmenu}}
+                        <div class="region_main_settings_menu_proxy"></div>
+                    {{/hasregionmainsettingsmenu}}
+                    {{{ output.course_content_header }}}
+                    {{{ output.main_content }}}
+                    {{{ output.activity_navigation }}}
+                    {{{ output.course_content_footer }}}
+
+                </section>
+            </div>
+        </div>
+    </div>
+    {{{ output.standard_after_main_region_html }}}
+    {{> theme_citricityxund/footer }}
+</div>
+
+</body>
+</html>
+{{#js}}
+M.util.js_pending('theme_boost/loader');
+require(['theme_boost/loader'], function() {
+    M.util.js_complete('theme_boost/loader');
+});
+
+M.util.js_pending('theme_boost/drawer');
+require(['theme_boost/drawer'], function(drawer) {
+    drawer.init();
+    M.util.js_complete('theme_boost/drawer');
+});
+{{/js}}


### PR DESCRIPTION
- I removed the side block region on the dashboard page. I did this by removing side-pre region for the dashboard page in config.php. I then added mydashboard.php and mydashboard template to be able to remove the region from the template.

- I added mydashboard.scss and outputted in main to contain our dashboard scss styles. I added stylings to the dashboard page and the blocks within to match the mockups.

- I modified the templates for block overview filters to use btn-link. For the pagination links for the recently accessed courses I just used styling, otherwise, I would need to overwrite core paginations which would be overly complex for a simple styling change.

- I modified the template for blocks in the theme to use h4 headings and adjust padding.

- I adjusted the coursecards templates to swap the category and course names around, and make the course names small h6 headings and uppercase.

- Removed logo from nav-drawer as requested.

