### PR TITLE
Remove requested nav elements.

### DIFF
--- a/scss/styles/navdrawer.scss
+++ b/scss/styles/navdrawer.scss
@@ -3,4 +3,12 @@
         background-color: $primary;
         color: $white;
     }
+
+    .list-group li {
+        &.home,
+        &.calendar,
+        &.privatefiles {
+            display: none;
+        }
+    }
 }

--- a/templates/flat_navigation.mustache
+++ b/templates/flat_navigation.mustache
@@ -8,7 +8,7 @@
             <ul>
         {{/showdivider}}
         {{#action}}
-            <li>
+            <li class="{{key}}">
                 <a class="list-group-item list-group-item-action {{#isactive}}active{{/isactive}} {{#classes}}{{.}} {{/classes}}" href="{{{action}}}" data-key="{{key}}" data-isexpandable="{{isexpandable}}" data-indent="{{get_indent}}" data-showdivider="{{showdivider}}" data-type="{{type}}" data-nodetype="{{nodetype}}" data-collapse="{{collapse}}" data-forceopen="{{forceopen}}" data-isactive="{{isactive}}" data-hidden="{{hidden}}" data-preceedwithhr="{{preceedwithhr}}" {{#parent.key}}data-parent-key="{{.}}"{{/parent.key}}>
                     <div class="ml-{{get_indent}}">
                         <div class="media">
@@ -19,7 +19,7 @@
             </li>
         {{/action}}
         {{^action}}
-            <li>
+            <li class="{{key}}">
                 <div class="list-group-item {{#classes}}{{.}} {{/classes}}" data-key="{{key}}" data-isexpandable="{{isexpandable}}" data-indent="{{get_indent}}" data-showdivider="{{showdivider}}" data-type="{{type}}" data-nodetype="{{nodetype}}" data-collapse="{{collapse}}" data-forceopen="{{forceopen}}" data-isactive="{{isactive}}" data-hidden="{{hidden}}" data-preceedwithhr="{{preceedwithhr}}" {{#parent.key}}data-parent-key="{{.}}"{{/parent.key}}>
                     <div class="ml-{{get_indent}}">
                         <div class="media">


### PR DESCRIPTION
To remove site home, calendar and private files.

I added the data key as a class name in the li element of the template. This is because the data key will have the same value across all moodle sites and unaffected by language changes.

I then used CSS to hide the 3 list items requested by that class.