### PR TITLE
Restyle navdrawer, navbar, and footer.

### DIFF
--- a/scss/styles/footer.scss
+++ b/scss/styles/footer.scss
@@ -5,4 +5,9 @@
     .footer-columns > .row > .col-sm-4:nth-child(1) {
         max-width: 20rem;
     }
+
+    a {
+        color: $white;
+        text-decoration: underline;
+    }
 }

--- a/scss/styles/general.scss
+++ b/scss/styles/general.scss
@@ -34,3 +34,24 @@ body {
 .form-control {
     border-radius: $input-border-radius;
 }
+
+// Page spacing.
+@include media-breakpoint-up(md) {
+    #page.drawers {
+        padding-left: 0;
+        padding-right: 0;
+
+        #topofscroll {
+            padding-left: 3rem;
+            padding-right: 3rem;
+        }
+    }
+}
+
+@include media-breakpoint-down(md) {
+    #page.drawers #topofscroll {
+        padding-left: 1rem;
+        padding-right: 1rem;
+        max-width: 100%;
+    }
+}

--- a/scss/styles/navbar.scss
+++ b/scss/styles/navbar.scss
@@ -5,7 +5,7 @@
 .navbar.fixed-top {
     height: $navbar-height;
     .navbar-brand {
-        height: $navbar-height - 5px;
+        height: $navbar-height;
 
         .logo {
             max-height: calc(#{$navbar-height} - (#{$primary-nav-padding-y} * 2));
@@ -46,5 +46,18 @@
         &:hover {
             color: darken(#65c1be, 15%);
         }
+    }
+}
+
+.primary-navigation .navigation .nav-link {
+    color: $navbar-light-color;
+    border-bottom: none;
+
+    &.active {
+        color: $navbar-light-hover-color;
+    }
+
+    &:hover {
+        background-color: transparent;
     }
 }

--- a/scss/styles/navdrawer.scss
+++ b/scss/styles/navdrawer.scss
@@ -4,10 +4,16 @@
         color: $white;
     }
 
-    .list-group li {
-        &.home,
-        &.calendar,
-        &.privatefiles {
+    .list-group {
+        // Admin link spacing.
+        [href$='/admin/search.php'] {
+            margin-top: 0.5rem;
+        }
+
+        // Remove home, calendar and private files link using url (classes no longer exist).
+        [href$='/?redirect=0'],
+        [href$='/calendar/view.php?view=month'],
+        [href$='/user/files.php'] {
             display: none;
         }
     }

--- a/templates/navbar.mustache
+++ b/templates/navbar.mustache
@@ -1,6 +1,6 @@
 <nav class="fixed-top navbar navbar-light bg-white navbar-expand moodle-has-zindex" aria-label="{{#str}}sitemenubar, admin{{/str}}">
 
-        <div data-region="drawer-toggle" class="d-inline-block mr-3">
+        <div data-region="drawer-toggle" class="d-inline-block mr-3 my-auto">
             <button aria-expanded="{{#navdraweropen}}true{{/navdraweropen}}{{^navdraweropen}}false{{/navdraweropen}}" aria-controls="nav-drawer" type="button" class="btn btn-link nav-link float-sm-left p-0 nav-drawer-button" data-action="toggle-drawer" data-side="left" data-preference="drawer-open-nav">{{#pix}}i/menubars{{/pix}}<span class="sr-only">{{#str}}sidepanel, core{{/str}}</span></button>
         </div>
 

--- a/templates/primary-drawer-mobile.mustache
+++ b/templates/primary-drawer-mobile.mustache
@@ -2,7 +2,7 @@
     <div class="list-group">
         {{#mobileprimarynav}}
             {{#haschildren}}
-            <a id="drop-down-{{sort}}" href="#" class="list-group-item list-group-item-action icons-collapse-expand collapsed d-flex" data-toggle="collapse" data-target="#drop-down-menu-{{sort}}" aria-expanded="false" aria-controls="drop-down-menu-{{sort}}">
+            <a id="drop-down-{{sort}}" href="#" class="font-weight-bold list-group-item list-group-item-action icons-collapse-expand collapsed d-flex" data-toggle="collapse" data-target="#drop-down-menu-{{sort}}" aria-expanded="false" aria-controls="drop-down-menu-{{sort}}">
                 {{{text}}}
                 <span class="ml-auto expanded-icon icon-no-margin mx-2">
                     {{#pix}} t/expanded, core {{/pix}}
@@ -17,7 +17,7 @@
                     </span>
                 </span>
             </a>
-            <div class="collapse list-group-item p-0 border-0" role="menu" id="drop-down-menu-{{sort}}" aria-labelledby="drop-down-{{sort}}">
+            <div class="collapse font-weight-bold list-group-item p-0 border-0" role="menu" id="drop-down-menu-{{sort}}" aria-labelledby="drop-down-{{sort}}">
                 {{#children}}
                     {{^divider}}
                             <a href="{{{url}}}" class="pl-5 bg-light list-group-item list-group-item-action">{{{text}}}</a>
@@ -26,7 +26,7 @@
             </div>
             {{/haschildren}}
             {{^haschildren}}
-            <a href="{{{url}}}" class="list-group-item list-group-item-action {{#isactive}}active{{/isactive}} {{#classes}}{{.}} {{/classes}}" {{#isactive}}aria-current="true"{{/isactive}}>
+            <a href="{{{url}}}" class="font-weight-bold list-group-item list-group-item-action {{#isactive}}active{{/isactive}} {{#classes}}{{.}} {{/classes}}" {{#isactive}}aria-current="true"{{/isactive}}>
                 {{{text}}}
             </a>
             {{/haschildren}}


### PR DESCRIPTION
- Fixed the blue footer links in the footer.
- Reorganised the padding of the page to the main content, so the footer can span the full width of the page.
- Styled the navbar to follow same styling as Moodle 3 version.
- Readded the site admin padding to the navdrawer, the bold font, and the hidden links from Moodle 3.
