### PR TITLE
Course page drawer layout rework

### DIFF
--- a/scss/pre.scss
+++ b/scss/pre.scss
@@ -44,6 +44,7 @@ $enable-responsive-font-sizes: true !default;
 
 // Body
 $body-color:    $primary !default;
+$course-content-maxwidth: 100% !default;
 
 // Fonts
 $font-family-sans-serif: Kiro-Regular, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";

--- a/scss/styles/course.scss
+++ b/scss/styles/course.scss
@@ -11,18 +11,14 @@
 // Full width header layout on course pages.
 .pagelayout-course,
 .pagelayout-incourse {
-    #page.drawers #topofscroll {
+    #page.drawers #topofscroll,
+    #page-header {
         padding-left: 0;
         padding-right: 0;
     }
 
     #page {
         overflow-x: hidden;
-    }
-
-    #page-header {
-        padding-left: 0;
-        padding-right: 0;
     }
 
     .page-context-header,

--- a/scss/styles/course.scss
+++ b/scss/styles/course.scss
@@ -17,10 +17,6 @@
         padding-right: 0;
     }
 
-    #page {
-        overflow-x: hidden;
-    }
-
     .page-context-header,
     #page-navbar,
     #page-content,

--- a/scss/styles/course.scss
+++ b/scss/styles/course.scss
@@ -8,6 +8,42 @@
     }
 }
 
+// Full width header layout on course pages.
+.pagelayout-course,
+.pagelayout-incourse {
+    #page.drawers #topofscroll {
+        padding-left: 0;
+        padding-right: 0;
+    }
+
+    #page {
+        overflow-x: hidden;
+    }
+
+    #page-header {
+        padding-left: 0;
+        padding-right: 0;
+    }
+
+    .page-context-header,
+    #page-navbar,
+    #page-content,
+    .secondary-navigation {
+        padding-left: 3rem;
+        padding-right: 3rem;
+    }
+
+    @include media-breakpoint-down(sm) {
+        .page-context-header,
+        #page-navbar,
+        #page-content,
+        .secondary-navigation {
+            padding-left: 1rem;
+            padding-right: 1rem;
+        }
+    }
+}
+
 .pagelayout-course {
     // Remove card and region borders.
     .card,

--- a/scss/styles/topics.scss
+++ b/scss/styles/topics.scss
@@ -1,27 +1,4 @@
-.course-content ul.topics li.section {
-    position: relative;
-    margin-top: 0;
-    padding-bottom: 1rem;
-    padding-top: 2rem;
-
-    &#section-0 {
-        padding-top: 0;
-    }
-
-    .section_availability {
-        position: absolute;
-        top: 0;
-
-        .availabilityinfo {
-            font-size: .75em;
-            font-style: italic;
-            color: #EB4F5A;
-
-            .badge-info {
-                font-size: .75rem;
-                background-color: #EB4F5A;
-                font-style: normal;
-            }
-        }
-    }
+.section_availability.course-description-item {
+    background-color: #EB4F5A;
+    color: #fff;
 }

--- a/templates/core/full_header.mustache
+++ b/templates/core/full_header.mustache
@@ -1,42 +1,35 @@
-<header id="page-header" class="row">
-   {{#headerimage}}
+<header id="page-header" class="header-maxwidth d-print-none">
+    {{#headerimage}}
     <div id="course-banner" class="col-12" style="background-image:url({{{headerimage}}}); background-repeat: no-repeat; background-position: center;">
     </div>
     {{/headerimage}}
-    <div class="col-12 pt-3 pb-3">
-        <div class="card {{^contextheader}}border-0 bg-transparent{{/contextheader}}">
-            <div class="card-body {{^contextheader}}p-2{{/contextheader}}">
-                <div class="d-sm-flex align-items-center">
-                    {{#contextheader}}
+    <div class="w-100 pt-3">
+        <div class="d-flex flex-wrap">
+            {{#hasnavbar}}
+            <div id="page-navbar">
+                {{{navbar}}}
+            </div>
+            {{/hasnavbar}}
+            <div class="ml-auto d-flex">
+                {{{pageheadingbutton}}}
+            </div>
+            <div id="course-header">
+                {{{courseheader}}}
+            </div>
+        </div>
+        <div class="d-flex align-items-center">
+            {{^welcomemessage}}
+                {{#contextheader}}
                     <div class="mr-auto">
                         {{{contextheader}}}
                     </div>
-                    {{/contextheader}}
-
-                    {{#settingsmenu}}
-                    <div class="context-header-settings-menu">
-                        {{{settingsmenu}}}
-                    </div>
-                    {{/settingsmenu}}
-                    <div class="header-actions-container flex-shrink-0" data-region="header-actions-container">
-                        {{#headeractions}}
-                            <div class="header-action ml-2">{{{.}}}</div>
-                        {{/headeractions}}
-                    </div>
-                </div>
-                <div class="d-flex flex-wrap">
-                    {{#hasnavbar}}
-                    <div id="page-navbar">
-                        {{{navbar}}}
-                    </div>
-                    {{/hasnavbar}}
-                    <div class="ml-auto d-flex">
-                        {{{pageheadingbutton}}}
-                    </div>
-                    <div id="course-header">
-                        {{{courseheader}}}
-                    </div>
-                </div>
+                {{/contextheader}}
+            {{/welcomemessage}}
+            {{> core/welcome }}
+            <div class="header-actions-container ml-auto" data-region="header-actions-container">
+                {{#headeractions}}
+                    <div class="header-action ml-2">{{{.}}}</div>
+                {{/headeractions}}
             </div>
         </div>
     </div>


### PR DESCRIPTION
- Reworked layout and spacing on the course page to look consistent with the older version on the new layout.
- Adjusted the page header to use the new features and functionality on 4, while maintaining the same spacing and changes on the older version.
- Coloured the new restriction message on topics, and removed the old broken css which was applied to the old message.