### PR TITLE
Postion footer at the bottom of the viewport.

### DIFF
--- a/scss/styles/footer.scss
+++ b/scss/styles/footer.scss
@@ -11,3 +11,14 @@
         text-decoration: underline;
     }
 }
+
+// Footer positioning at bottom of viewport.
+@include media-breakpoint-up(sm) {
+    #page-wrapper #page {
+        min-height: calc(100vh - #{$navbar-height});
+
+        #topofscroll {
+            flex: 1;
+        }
+    }
+}

--- a/scss/styles/footer.scss
+++ b/scss/styles/footer.scss
@@ -13,12 +13,10 @@
 }
 
 // Footer positioning at bottom of viewport.
-@include media-breakpoint-up(sm) {
-    #page-wrapper #page {
-        min-height: calc(100vh - #{$navbar-height});
+#page-wrapper #page {
+    min-height: calc(100vh - #{$navbar-height});
 
-        #topofscroll {
-            flex: 1;
-        }
+    #topofscroll {
+        flex: 1;
     }
 }


### PR DESCRIPTION
Page element already uses flexbox. I applied a min-height 100vh so it spans the full height of the viewport (deducting the navbar it doesn't contain to prevent scroll issues).

I then applied flex: 1 to the main content element (#topofscroll) so this element occupies all the unused space in the viewport, so the footer remains at the bottom of the page.