### PR TITLE
Kprime question type styling.

### DIFF
--- a/scss/styles/quiz.scss
+++ b/scss/styles/quiz.scss
@@ -35,8 +35,14 @@
   border-radius: 0 !important;
 }
 
-.que.ddwtos .group4 {
-  background-color: #ACDADC;
+.que.ddwtos {
+  .group4 {
+    background-color: #ACDADC;
+  }
+
+  .group5 {
+    background-color: #E8AAAE;
+  }
 }
 
 // Kprime question type.

--- a/scss/styles/quiz.scss
+++ b/scss/styles/quiz.scss
@@ -38,3 +38,56 @@
 .que.ddwtos .group4 {
   background-color: #ACDADC;
 }
+
+// Kprime question type.
+.kprime {
+  .qtext {
+    font-size: 18px !important;
+    color: #000;
+  }
+
+  .generaltable {
+    font-size: 16px;
+    color: #000;
+
+    input[type="radio"], input[type="checkbox"] {
+      accent-color: #000;
+    }
+
+    .icon.fa-check-square {
+      color: $success;
+      margin-left: 5px;
+
+    }
+
+    .icon.fa-remove {
+      margin-left: 5px;
+    }
+
+    .kprimegreyingout {
+      opacity: 1;
+    }
+
+    tr,
+    td {
+      border-bottom: 1px solid $body-copy-color;
+      border-top: 0;
+    }
+
+    thead {
+      th,
+      td {
+        border-bottom: 0;
+        border-top: 0;
+      }
+    }
+
+    tr {
+      &:hover,
+      &:nth-of-type(odd) {
+        color: #000;
+        background-color: transparent;
+      }
+    }
+  }
+}

--- a/scss/styles/quiz.scss
+++ b/scss/styles/quiz.scss
@@ -40,7 +40,7 @@
     background-color: #ACDADC;
   }
 
-  .group5 {
+  .group1 {
     background-color: #E8AAAE;
   }
 }

--- a/scss/styles/quiz.scss
+++ b/scss/styles/quiz.scss
@@ -51,10 +51,11 @@
 
   .generaltable {
     font-size:  $font-size-normal;
-    color: #000;
+    color: $body-copy-color;
 
-    input[type="radio"], input[type="checkbox"] {
-      accent-color: #000;
+    input[type="radio"],
+    input[type="checkbox"] {
+      accent-color: $body-copy-color;
     }
 
     .icon.fa-check-square {
@@ -88,7 +89,7 @@
     tr {
       &:hover,
       &:nth-of-type(odd) {
-        color: #000;
+        color: $body-copy-color;
         background-color: transparent;
       }
     }

--- a/scss/styles/quiz.scss
+++ b/scss/styles/quiz.scss
@@ -41,13 +41,16 @@
 
 // Kprime question type.
 .kprime {
+  $font-size-large: 18px;
+  $font-size-normal: 16px;
+
   .qtext {
-    font-size: 18px !important;
+    font-size: $font-size-large !important;
     color: #000;
   }
 
   .generaltable {
-    font-size: 16px;
+    font-size:  $font-size-normal;
     color: #000;
 
     input[type="radio"], input[type="checkbox"] {

--- a/version.php
+++ b/version.php
@@ -4,7 +4,7 @@
 defined('MOODLE_INTERNAL') || die();                                                                                                
                                                                                                                                     
 // This is the version of the plugin.                                                                                               
-$plugin->version = '2023091400';
+$plugin->version = '2023120400';
 
 // This is the version of Moodle this plugin requires.                                                                              
 $plugin->requires = '2022041900'; // Moodle 4.0.                                                                                                 
@@ -13,7 +13,7 @@ $plugin->requires = '2022041900'; // Moodle 4.0.
 // for themes and should be the same as the name of the folder.                                                                     
 $plugin->component = 'theme_citricityxund';
 
-$plugin->release = 'v1.1.1';
+$plugin->release = 'v1.1.2';
                                                                                                                                     
 // This is a list of plugins, this plugin depends on (and their versions).                                                          
 $plugin->dependencies = [                                                                                                           


### PR DESCRIPTION
Styling the Kprime question type.

Had to use !important once unfortunately to override font size. This is because the customer has requested a set font size regardless of the tags used. As p tags for example are more specific than just targeting the class, important was needed.

