### PR TITLE
Course index focus state.

### DIFF
--- a/scss/styles/course.scss
+++ b/scss/styles/course.scss
@@ -80,6 +80,7 @@
 .courseindex-section:focus {
     margin-bottom: 3px;
     margin-top: 3px;
+    box-shadow: none !important;
 }
 .courseindex .courseindex-item,
 .courseindex .courseindex-item.dimmed {
@@ -203,6 +204,7 @@
         padding-top: 1rem;
         padding-bottom: 1rem;
         position: relative;
+        scroll-margin-top: 70px;
 
         .course-content-item-content {
             margin-top: 1rem !important;

--- a/version.php
+++ b/version.php
@@ -4,7 +4,7 @@
 defined('MOODLE_INTERNAL') || die();                                                                                                
                                                                                                                                     
 // This is the version of the plugin.                                                                                               
-$plugin->version = '2024040501';
+$plugin->version = '2024050100';
 
 // This is the version of Moodle this plugin requires.                                                                              
 $plugin->requires = '2022041900'; // Moodle 4.0.                                                                                                 
@@ -13,7 +13,7 @@ $plugin->requires = '2022041900'; // Moodle 4.0.
 // for themes and should be the same as the name of the folder.                                                                     
 $plugin->component = 'theme_citricityxund';
 
-$plugin->release = 'v1.1.7';
+$plugin->release = 'v1.1.8';
                                                                                                                                     
 // This is a list of plugins, this plugin depends on (and their versions).                                                          
 $plugin->dependencies = [                                                                                                           


### PR DESCRIPTION
After doing some investigation it appears that the two focus states are tracking two different things. It appears the outline styling is just the last item which item is clicked on (focus state). The solid colour state seems to just track which topic is at the top of the page view.

I have made two changes which will hopefully correct the issue. I have removed the outline focus state so it is no longer confusing.

Secondly, I noticed that when a topic is clicked and it scrolls to the anchor of that section, actually the topic below it was shown as that solid blue page item state. I added some scroll-margin-top so the correct section is active at the top of the page.